### PR TITLE
Allow to compare arrays recursively

### DIFF
--- a/tests/input_test.php
+++ b/tests/input_test.php
@@ -2870,12 +2870,44 @@ class ezcConsoleInputTest extends ezcTestCase
             'ezcConsoleOptionExclusionViolationException'
         );
     }
+
+    private function arrayRecursiveDiff($aArray1, $aArray2)
+    {
+        $aReturn = array();
+
+        foreach ($aArray1 as $mKey => $mValue)
+        {
+            if (array_key_exists($mKey, $aArray2))
+            {
+                if (is_array($mValue))
+                {
+                      $aRecursiveDiff = $this->arrayRecursiveDiff($mValue, $aArray2[$mKey]);
+                      if (count($aRecursiveDiff))
+                      {
+                          $aReturn[$mKey] = $aRecursiveDiff;
+                      }
+                }
+                else
+                {
+                    if ($mValue != $aArray2[$mKey])
+                    {
+                        $aReturn[$mKey] = $mValue;
+                    }
+                }
+            }
+            else
+            {
+                $aReturn[$mKey] = $mValue;
+            }
+        }
+        return $aReturn;
+    }
     
     private function commonProcessTestSuccess( $args, $res )
     {
         $this->input->process( $args );
         $values = $this->input->getOptionValues();
-        $this->assertTrue( count( array_diff( $res, $values ) ) == 0, 'Parameters processed incorrectly.' );
+        $this->assertTrue( count( $this->arrayRecursiveDiff( $res, $values ) ) == 0, 'Parameters processed incorrectly.' );
     }
     
     private function commonProcessTestFailure( $args, $exceptionClass, $message = null )


### PR DESCRIPTION
commonProcessTestSuccess currently fails to compare arrays that contains another array.

Author: Marius Ghita mhitza@gmail.com
Origin: other, https://stackoverflow.com/questions/3876435/recursive-array-diff#3877494
