### PR TITLE
Fix travis-ci builds

### DIFF
--- a/tests/data/posix/ezcConsoleMenuDialogTest__testDialog1.php
+++ b/tests/data/posix/ezcConsoleMenuDialogTest__testDialog1.php
@@ -24,6 +24,8 @@
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
+require_once dirname(__FILE__) . "/../../../vendor/autoload.php";
+
 $out = new ezcConsoleOutput();
 
 $opts = new ezcConsoleMenuDialogOptions();

--- a/tests/data/posix/ezcConsoleMenuDialogTest__testDialog2.php
+++ b/tests/data/posix/ezcConsoleMenuDialogTest__testDialog2.php
@@ -24,6 +24,8 @@
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
+require_once dirname(__FILE__) . "/../../../vendor/autoload.php";
+
 $out = new ezcConsoleOutput();
 
 $opts = new ezcConsoleMenuDialogOptions();

--- a/tests/data/posix/ezcConsoleMenuDialogTest__testDialog3.php
+++ b/tests/data/posix/ezcConsoleMenuDialogTest__testDialog3.php
@@ -24,6 +24,8 @@
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
+require_once dirname(__FILE__) . "/../../../vendor/autoload.php";
+
 $out = new ezcConsoleOutput();
 
 $opts = new ezcConsoleMenuDialogOptions();

--- a/tests/data/posix/ezcConsoleMenuDialogTest__testDialog4.php
+++ b/tests/data/posix/ezcConsoleMenuDialogTest__testDialog4.php
@@ -24,6 +24,8 @@
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
+require_once dirname(__FILE__) . "/../../../vendor/autoload.php";
+
 $out = new ezcConsoleOutput();
 
 $opts = new ezcConsoleMenuDialogOptions();

--- a/tests/data/posix/ezcConsoleQuestionDialogTest__testDialog1.php
+++ b/tests/data/posix/ezcConsoleQuestionDialogTest__testDialog1.php
@@ -24,6 +24,8 @@
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
+require_once dirname(__FILE__) . "/../../../vendor/autoload.php";
+
 $out = new ezcConsoleOutput();
 
 $opts = new ezcConsoleQuestionDialogOptions();

--- a/tests/data/posix/ezcConsoleQuestionDialogTest__testDialog2.php
+++ b/tests/data/posix/ezcConsoleQuestionDialogTest__testDialog2.php
@@ -24,6 +24,8 @@
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
+require_once dirname(__FILE__) . "/../../../vendor/autoload.php";
+
 $out = new ezcConsoleOutput();
 
 $opts = new ezcConsoleQuestionDialogOptions();

--- a/tests/data/posix/ezcConsoleQuestionDialogTest__testDialog3.php
+++ b/tests/data/posix/ezcConsoleQuestionDialogTest__testDialog3.php
@@ -24,6 +24,8 @@
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
+require_once dirname(__FILE__) . "/../../../vendor/autoload.php";
+
 $out = new ezcConsoleOutput();
 
 $dialog = ezcConsoleQuestionDialog::YesNoQuestion( $out, "Is the answer to everything 42?", "y" );

--- a/tests/data/posix/ezcConsoleQuestionDialogTest__testDialog4.php
+++ b/tests/data/posix/ezcConsoleQuestionDialogTest__testDialog4.php
@@ -24,6 +24,8 @@
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
+require_once dirname(__FILE__) . "/../../../vendor/autoload.php";
+
 $out = new ezcConsoleOutput();
 
 $opts = new ezcConsoleQuestionDialogOptions();

--- a/tests/data/posix/ezcConsoleQuestionDialogTest__testDialog5.php
+++ b/tests/data/posix/ezcConsoleQuestionDialogTest__testDialog5.php
@@ -24,6 +24,8 @@
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
+require_once dirname(__FILE__) . "/../../../vendor/autoload.php";
+
 $out = new ezcConsoleOutput();
 
 $opts = new ezcConsoleQuestionDialogOptions();

--- a/tests/data/windows/ezcConsoleMenuDialogTest__testDialog1.php
+++ b/tests/data/windows/ezcConsoleMenuDialogTest__testDialog1.php
@@ -24,6 +24,8 @@
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
+require_once dirname(__FILE__) . "/../../../vendor/autoload.php";
+
 $out = new ezcConsoleOutput();
 
 $opts = new ezcConsoleMenuDialogOptions();

--- a/tests/data/windows/ezcConsoleMenuDialogTest__testDialog2.php
+++ b/tests/data/windows/ezcConsoleMenuDialogTest__testDialog2.php
@@ -24,6 +24,8 @@
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
+require_once dirname(__FILE__) . "/../../../vendor/autoload.php";
+
 $out = new ezcConsoleOutput();
 
 $opts = new ezcConsoleMenuDialogOptions();

--- a/tests/data/windows/ezcConsoleMenuDialogTest__testDialog3.php
+++ b/tests/data/windows/ezcConsoleMenuDialogTest__testDialog3.php
@@ -24,6 +24,8 @@
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
+require_once dirname(__FILE__) . "/../../../vendor/autoload.php";
+
 $out = new ezcConsoleOutput();
 
 $opts = new ezcConsoleMenuDialogOptions();

--- a/tests/data/windows/ezcConsoleMenuDialogTest__testDialog4.php
+++ b/tests/data/windows/ezcConsoleMenuDialogTest__testDialog4.php
@@ -24,6 +24,8 @@
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
+require_once dirname(__FILE__) . "/../../../vendor/autoload.php";
+
 $out = new ezcConsoleOutput();
 
 $opts = new ezcConsoleMenuDialogOptions();

--- a/tests/data/windows/ezcConsoleQuestionDialogTest__testDialog1.php
+++ b/tests/data/windows/ezcConsoleQuestionDialogTest__testDialog1.php
@@ -24,6 +24,8 @@
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
+require_once dirname(__FILE__) . "/../../../vendor/autoload.php";
+
 $out = new ezcConsoleOutput();
 
 $opts = new ezcConsoleQuestionDialogOptions();

--- a/tests/data/windows/ezcConsoleQuestionDialogTest__testDialog2.php
+++ b/tests/data/windows/ezcConsoleQuestionDialogTest__testDialog2.php
@@ -24,6 +24,8 @@
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
+require_once dirname(__FILE__) . "/../../../vendor/autoload.php";
+
 $out = new ezcConsoleOutput();
 
 $opts = new ezcConsoleQuestionDialogOptions();

--- a/tests/data/windows/ezcConsoleQuestionDialogTest__testDialog3.php
+++ b/tests/data/windows/ezcConsoleQuestionDialogTest__testDialog3.php
@@ -24,6 +24,8 @@
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
+require_once dirname(__FILE__) . "/../../../vendor/autoload.php";
+
 $out = new ezcConsoleOutput();
 
 $dialog = ezcConsoleQuestionDialog::YesNoQuestion( $out, "Is the answer to everything 42?", "y" );

--- a/tests/data/windows/ezcConsoleQuestionDialogTest__testDialog4.php
+++ b/tests/data/windows/ezcConsoleQuestionDialogTest__testDialog4.php
@@ -24,6 +24,8 @@
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
+require_once dirname(__FILE__) . "/../../../vendor/autoload.php";
+
 $out = new ezcConsoleOutput();
 
 $opts = new ezcConsoleQuestionDialogOptions();

--- a/tests/data/windows/ezcConsoleQuestionDialogTest__testDialog5.php
+++ b/tests/data/windows/ezcConsoleQuestionDialogTest__testDialog5.php
@@ -24,6 +24,8 @@
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
+require_once dirname(__FILE__) . "/../../../vendor/autoload.php";
+
 $out = new ezcConsoleOutput();
 
 $opts = new ezcConsoleQuestionDialogOptions();


### PR DESCRIPTION
When phpunit is run from the shell, `$_SERVER["_"]` is populated with `phpunit` (https://github.com/zetacomponents/ConsoleTools/blob/master/tests/dialog_test.php#L61) which is used right after by `proc_open()` (https://github.com/zetacomponents/ConsoleTools/blob/master/tests/dialog_test.php#L100) to run the resources scripts, using the composer autoloading mechanism. This is why it works from the command line and not from travis.
The real fix is to include the composer autoload file in the resources files, as done in #2 759b9f5e
