### PR TITLE
PHP 8.1: fix method signature deprecation warnings

### DIFF
--- a/src/input/arguments.php
+++ b/src/input/arguments.php
@@ -60,6 +60,7 @@ class ezcConsoleArguments implements ArrayAccess, Iterator, Countable
      * @throws ezcBaseValueException
      *         If the provided offset is neither an integer, nor a string.
      */
+    #[ReturnTypeWillChange]
     public function offsetExists( $offset )
     {
         switch ( gettype( $offset ) )
@@ -74,18 +75,19 @@ class ezcConsoleArguments implements ArrayAccess, Iterator, Countable
     }
 
     /**
-     * Returns the element with the given offset. 
+     * Returns the element with the given offset.
      * This method is part of the ArrayAccess interface to allow access to the
      * data of this object as if it was an array. Valid offsets are integers or
      * strings. If an integer is used, it refers to the position in the command
      * line. A string refers to the arguments name property.
-     * 
+     *
      * @param string|integer $offset The offset to check.
      * @return ezcConsoleArgument
      *
      * @throws ezcBaseValueException
      *         If the provided offset is neither an integer, nor a string.
      */
+    #[ReturnTypeWillChange]
     public function offsetGet( $offset )
     {
         switch ( gettype( $offset ) )
@@ -126,6 +128,7 @@ class ezcConsoleArguments implements ArrayAccess, Iterator, Countable
      * @throws ezcConsoleArgumentAlreadyRegisteredException
      *         If an argument with the given offset or name is already registered.
      */
+    #[ReturnTypeWillChange]
     public function offsetSet( $offset, $value )
     {
         // Determine key if not set (using $obj[] = ...)
@@ -178,6 +181,7 @@ class ezcConsoleArguments implements ArrayAccess, Iterator, Countable
      * @throws ezcBaseValueException
      *         If a non numeric row offset is used.
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset( $offset )
     {
         // Set access only allowed with integer values
@@ -193,9 +197,10 @@ class ezcConsoleArguments implements ArrayAccess, Iterator, Countable
     /**
      * Returns the currently selected argument from the list.
      * Used by foreach-Loops.
-     * 
+     *
      * @return ezcConsoleArgument
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return current( $this->ordered );
@@ -209,17 +214,19 @@ class ezcConsoleArguments implements ArrayAccess, Iterator, Countable
      * 
      * @return string
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return key( $this->ordered );
     }
 
     /**
-     * Advances the internal pointer to the next argument and returns it. 
+     * Advances the internal pointer to the next argument and returns it.
      * Used by foreach-Loops.
-     * 
+     *
      * @return ezcConsoleArgument
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         return next( $this->ordered );
@@ -228,9 +235,10 @@ class ezcConsoleArguments implements ArrayAccess, Iterator, Countable
     /**
      * Rewinds the internal pointer to the first argument and returns it.
      * Used by foreach-Loops.
-     * 
+     *
      * @return ezcConsoleArgument
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         // Called before foreach
@@ -244,6 +252,7 @@ class ezcConsoleArguments implements ArrayAccess, Iterator, Countable
      * 
      * @return bool
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return ( current( $this->ordered ) !== false );
@@ -254,6 +263,7 @@ class ezcConsoleArguments implements ArrayAccess, Iterator, Countable
      * 
      * @return int
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count( $this->ordered );

--- a/src/structs/output_formats.php
+++ b/src/structs/output_formats.php
@@ -83,6 +83,7 @@ class ezcConsoleOutputFormats implements Iterator, Countable
      * 
      * @return ezcConsoleOutputFormat
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return current( $this->formats );
@@ -95,6 +96,7 @@ class ezcConsoleOutputFormats implements Iterator, Countable
      * 
      * @return ezcConsoleOutputFormat|bool
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         return next( $this->formats );
@@ -107,6 +109,7 @@ class ezcConsoleOutputFormats implements Iterator, Countable
      * 
      * @return string
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return key( $this->formats );
@@ -119,6 +122,7 @@ class ezcConsoleOutputFormats implements Iterator, Countable
      * 
      * @return ezcConsoleOutputFormat
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         return reset( $this->formats );
@@ -131,6 +135,7 @@ class ezcConsoleOutputFormats implements Iterator, Countable
      * 
      * @return bool
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return ( current( $this->formats ) !== false );
@@ -143,6 +148,7 @@ class ezcConsoleOutputFormats implements Iterator, Countable
      * 
      * @return void
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count( $this->formats );

--- a/src/table.php
+++ b/src/table.php
@@ -288,6 +288,7 @@ class ezcConsoleTable implements Countable, Iterator, ArrayAccess
      * @throws ezcBaseValueException
      *         If a non numeric row ID is requested.
      */
+    #[ReturnTypeWillChange]
     public function offsetExists( $offset )
     {
         if ( !is_int( $offset ) || $offset < 0 )
@@ -312,6 +313,7 @@ class ezcConsoleTable implements Countable, Iterator, ArrayAccess
      * @throws ezcBaseValueException
      *         If a non numeric row ID is requested.
      */
+    #[ReturnTypeWillChange]
     public function offsetGet( $offset )
     {
         $offset = ( $offset === null ) ? count( $this->rows ) : $offset;
@@ -340,6 +342,7 @@ class ezcConsoleTable implements Countable, Iterator, ArrayAccess
      * @throws ezcBaseValueException
      *         If the provided value is not of type {@link ezcConsoleTableRow}.
      */
+    #[ReturnTypeWillChange]
     public function offsetSet( $offset, $value )
     {
         if ( !( $value instanceof ezcConsoleTableRow ) )
@@ -368,6 +371,7 @@ class ezcConsoleTable implements Countable, Iterator, ArrayAccess
      * @throws ezcBaseValueException
      *         If a non numeric row ID is requested.
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset( $offset )
     {
         if ( !is_int( $offset ) || $offset < 0 )
@@ -387,6 +391,7 @@ class ezcConsoleTable implements Countable, Iterator, ArrayAccess
      *
      * @return int Number of cells in this row.
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         $keys = array_keys( $this->rows );
@@ -401,6 +406,7 @@ class ezcConsoleTable implements Countable, Iterator, ArrayAccess
      *
      * @return ezcConsoleTableCell The currently selected cell.
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return current( $this->rows );
@@ -414,6 +420,7 @@ class ezcConsoleTable implements Countable, Iterator, ArrayAccess
      *
      * @return int The key of the currently selected cell.
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return key( $this->rows );
@@ -427,6 +434,7 @@ class ezcConsoleTable implements Countable, Iterator, ArrayAccess
      *
      * @return mixed ezcConsoleTableCell if the next cell exists, or false.
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         return next( $this->rows );
@@ -440,6 +448,7 @@ class ezcConsoleTable implements Countable, Iterator, ArrayAccess
      *
      * @return ezcConsoleTableCell The very first cell of this row.
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         return reset( $this->rows );
@@ -453,6 +462,7 @@ class ezcConsoleTable implements Countable, Iterator, ArrayAccess
      *
      * @return ezcConsoleTableCell The very first cell of this row.
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return current( $this->rows ) !== false;

--- a/src/table/row.php
+++ b/src/table/row.php
@@ -129,6 +129,7 @@ class ezcConsoleTableRow implements Countable, Iterator, ArrayAccess
      * @throws ezcBaseValueException
      *         If a non numeric cell ID is requested.
      */
+    #[ReturnTypeWillChange]
     public function offsetExists( $offset )
     {
         if ( !is_int( $offset ) || $offset < 0 )
@@ -151,6 +152,7 @@ class ezcConsoleTableRow implements Countable, Iterator, ArrayAccess
      * @throws ezcBaseValueException
      *         If a non numeric cell ID is requested.
      */
+    #[ReturnTypeWillChange]
     public function offsetGet( $offset )
     {
         if ( !isset( $offset ) )
@@ -183,6 +185,7 @@ class ezcConsoleTableRow implements Countable, Iterator, ArrayAccess
      * @throws ezcBaseValueException
      *         If the provided value is not of type {@ling ezcConsoleTableCell}.
      */
+    #[ReturnTypeWillChange]
     public function offsetSet( $offset, $value )
     {
         if ( !( $value instanceof ezcConsoleTableCell ) )
@@ -211,6 +214,7 @@ class ezcConsoleTableRow implements Countable, Iterator, ArrayAccess
      * @throws ezcBaseValueException
      *         If a non numeric cell ID is requested.
      */
+    #[ReturnTypeWillChange]
     public function offsetUnset( $offset )
     {
         if ( !is_int( $offset ) || $offset < 0 )
@@ -230,6 +234,7 @@ class ezcConsoleTableRow implements Countable, Iterator, ArrayAccess
      *
      * @return int Number of cells in this row.
      */
+    #[ReturnTypeWillChange]
     public function count()
     {
         $keys = array_keys( $this->cells );
@@ -244,6 +249,7 @@ class ezcConsoleTableRow implements Countable, Iterator, ArrayAccess
      * 
      * @return ezcConsoleTableCell The currently selected cell.
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return current( $this->cells );
@@ -257,6 +263,7 @@ class ezcConsoleTableRow implements Countable, Iterator, ArrayAccess
      * 
      * @return int The key of the currently selected cell.
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return key( $this->cells );
@@ -270,6 +277,7 @@ class ezcConsoleTableRow implements Countable, Iterator, ArrayAccess
      *
      * @return mixed ezcConsoleTableCell if the next cell exists, or false.
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         return next( $this->cells );
@@ -283,6 +291,7 @@ class ezcConsoleTableRow implements Countable, Iterator, ArrayAccess
      *
      * @return ezcConsoleTableCell The very first cell of this row.
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         return reset( $this->cells );
@@ -296,6 +305,7 @@ class ezcConsoleTableRow implements Countable, Iterator, ArrayAccess
      *
      * @return ezcConsoleTableCell The very first cell of this row.
      */
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return current( $this->cells ) !== false;


### PR DESCRIPTION
As of PHP 8.1, PHP will start throwing deprecation warnings along the lines of:
```
Deprecated:  Return type of [CLASS]::[METHOD]() should either be compatible with [PHP NATIVE INTERFACE]::[METHOD](): [TYPE], or the #[ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
```

These type of deprecation notices relate to the [Return types for internal methods RFC](https://wiki.php.net/rfc/internal_method_return_types) in PHP 8.1.

Basically, as of PHP 8.1, these methods in classes which implement PHP native interfaces are expected to have a return type declared.
The return type can be the same as used in PHP itself or a more specific type. This complies with the Liskov principle of covariance, which allows the return type of a child overloaded method to be more specific than that of the parent.

As per the conversation in #16, these are now fixed by using the suggested attribute.

While attributes are a PHP 8.0 feature only, due to the syntax choice for `#[]`, they will ignored in PHP < 8 and can be safely added.