### PR TITLE
.gitignore: ignore PHPUnit cache file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ run-tests-tmp
 extract
 composer.lock
 composer.phar
+.phpunit.result.cache


### PR DESCRIPTION
As of PHPUnit 8, PHPUnit generates a cache file. This file should not be committed.