### PR TITLE
Do not increment boolean variables

### DIFF
--- a/src/input/help_generators/standard.php
+++ b/src/input/help_generators/standard.php
@@ -318,7 +318,7 @@ class ezcConsoleInputStandardHelpGenerator implements ezcConsoleInputHelpGenerat
         $synopsis = '';
 
         // Break after a nesting level of 2
-        if ( $depth++ > 2 || ( in_array( $option->short, $usedOptions['short'] ) && in_array( $option->long, $usedOptions['long'] ) ) ) return $synopsis;
+        if ( (!is_bool($depth) && $depth++ > 2) || ( in_array( $option->short, $usedOptions['short'] ) && in_array( $option->long, $usedOptions['long'] ) ) ) return $synopsis;
         
         $usedOptions['short'][] = $option->short;
         $usedOptions['long'][]  = $option->long;


### PR DESCRIPTION
Before php8.3, incrementing/decrementing boolean variables have no effect. In php8.3, an E_WARNING is emitted to let users know about the lack of effect of the operation, which may cause test suite failures. Starting in php8.4, those operations will have a new effect over the variable. Let's avoid these output changes by not performing inc/dec operations over booleans. For further reference, please see https://wiki.php.net/rfc/saner-inc-dec-operators.