### PR TITLE
Drop unused arg, fix Increment on type bool

### DIFF
--- a/src/input/help_generators/standard.php
+++ b/src/input/help_generators/standard.php
@@ -276,13 +276,12 @@ class ezcConsoleInputStandardHelpGenerator implements ezcConsoleInputHelpGenerat
     public function generateSynopsis( array $optionFilter = null )
     {
         $usedOptions = array( 'short' => array(), 'long' => array() );
-        $allowsArgs = true;
         $synopsis = '$ ' . ( isset( $argv ) && sizeof( $argv ) > 0 ? $argv[0] : $_SERVER['argv'][0] ) . ' ';
         foreach ( $this->input->getOptions() as $option )
         {
             if ( $optionFilter === null || in_array( $option->short, $optionFilter ) ||  in_array( $option->long, $optionFilter ) )
             {
-                $synopsis .= $this->createOptionSynopsis( $option, $usedOptions, $allowsArgs );
+                $synopsis .= $this->createOptionSynopsis( $option, $usedOptions );
             }
         }
         if ( $this->input->argumentDefinition === null )


### PR DESCRIPTION
Without: 

```
PHPUnit 9.6.16 by Sebastian Bergmann and contributors.

Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

...............................................................  63 / 744 (  8%)
...........................................................EEEE 126 / 744 ( 16%)
EE...EEEEEE.................................................... 189 / 744 ( 25%)
............................................................... 252 / 744 ( 33%)
............................................................... 315 / 744 ( 42%)
............................................................... 378 / 744 ( 50%)
............................................................... 441 / 744 ( 59%)
............................................................... 504 / 744 ( 67%)
............................................................... 567 / 744 ( 76%)
............................................................... 630 / 744 ( 84%)
............................................................... 693 / 744 ( 93%)
...................................................             744 / 744 (100%)

Time: 00:00.063, Memory: 10.00 MB

There were 12 errors:

1) ezcConsoleInputTest::testGetSynopsis
Increment on type bool has no effect, this will change in the next major version of PHP

/dev/shm/BUILDROOT/php-zetacomponents-console-tools-1.7.3-8.fc39.remi.x86_64/usr/share/php/ezc/ConsoleTools/input/help_generators/standard.php:321
/dev/shm/BUILDROOT/php-zetacomponents-console-tools-1.7.3-8.fc39.remi.x86_64/usr/share/php/ezc/ConsoleTools/input/help_generators/standard.php:285
/dev/shm/BUILDROOT/php-zetacomponents-console-tools-1.7.3-8.fc39.remi.x86_64/usr/share/php/ezc/ConsoleTools/input.php:1018
/dev/shm/BUILD/ConsoleTools-fbc31f1be66ccd178c68d846d7c0ae09dbb97c89/tests/input_test.php:2315
...
```

With 

```
PHPUnit 9.6.16 by Sebastian Bergmann and contributors.

Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

...............................................................  63 / 744 (  8%)
............................................................... 126 / 744 ( 16%)
............................................................... 189 / 744 ( 25%)
............................................................... 252 / 744 ( 33%)
............................................................... 315 / 744 ( 42%)
............................................................... 378 / 744 ( 50%)
............................................................... 441 / 744 ( 59%)
............................................................... 504 / 744 ( 67%)
............................................................... 567 / 744 ( 76%)
............................................................... 630 / 744 ( 84%)
............................................................... 693 / 744 ( 93%)
...................................................             744 / 744 (100%)

Time: 00:00.057, Memory: 10.00 MB

OK (744 tests, 1557 assertions)

```
